### PR TITLE
feat!(jest): add testMatch to default config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = require('./packages/jest/jest.config');
 
-module.exports.testMatch = ['**/__tests__/**/*.spec.ts'];
 module.exports.testPathIgnorePatterns.push('/bootstrap-starter/');

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -120,3 +120,29 @@ Manual Install
    Where `test.concurrent` comes [from Jest](https://jestjs.io/docs/api#testconcurrentname-fn-timeout) and `runner.run` comes [from near-runner](https://github.com/near/runner-js#how-it-works).
 
 See the [`__tests__`](https://github.com/near/runner-js/tree/main/__tests__) directory in near-runner-js for more examples. Remember that you can replace the nested `test.concurrent`…`await runner.run` sequences with `runner.test`.
+
+Configuring Jest
+================
+
+By default, near-runner-jest includes a minimal [jest.config.js](./jest.config.js). To override or extend these settings, add your own `jest.config.js` to the root of your project and import near-runner-jest's as a starting point. For example, to set `testMatch` back to [Jest's default](https://jestjs.io/docs/configuration#testmatch-arraystring):
+
+```js
+const config = require('near-runner-jest/jest.config');
+
+module.exports = {
+  ...config,
+  testMatch: [
+    "**/__tests__/**/*.[jt]s?(x)",
+    "**/?(*.)+(spec|test).[jt]s?(x)"
+  ]
+}
+```
+
+If you want to put this `jest.config.js` somewhere other than your project root, you may need to update your `test` script in `package.json`:
+
+```diff
+- "test": "near-runner-jest"
++ "test": "near-runner-jest --config ./jest.config.js"
+```
+
+Note that command-line flags other than `--bootstrap` get passed along to the `jest` command; see [Jest's CLI options](https://jestjs.io/docs/cli) for possibilities.

--- a/packages/jest/jest.config.js
+++ b/packages/jest/jest.config.js
@@ -5,6 +5,10 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   rootDir: process.cwd(),
+  testMatch: [
+    '**/__tests__/**/*.(spec|test).[jt]s?(x)',
+    '**/?(*.)+(spec|test).[jt]s?(x)',
+  ],
   setupFilesAfterEnv: [
     path.join(__dirname, 'scripts', 'setup.js'),
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5575,6 +5575,41 @@ near-api-js@near/near-api-js#spike/sandbox-runner-tweaks:
     text-encoding-utf-8 "^1.0.2"
     tweetnacl "^1.0.1"
 
+near-runner-jest@0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/near-runner-jest/-/near-runner-jest-0.1.11.tgz#dafab9f0b1794bca097367bc915603f77148581d"
+  integrity sha512-uGme6tXKT0eT7W1nVRkcTsYo9s+DKHguDqRbe5abUC/43kIym8CZX0fpe4q03j4IvM8Gw0CxvRQk5CzC4eBghg==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    "@types/jest" "^27.0.1"
+    "@types/node" "^16.4.10"
+    fs-extra "^10.0.0"
+    jest "^27.0.6"
+    near-runner "0.6.1"
+    ts-jest "^27.0.4"
+    ts-node "^10.1.0"
+    typescript "^4.3.5"
+
+near-runner@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/near-runner/-/near-runner-0.6.1.tgz#e098664543a385f84ce5bea71c1d7146011703ab"
+  integrity sha512-ddcmO5qkVRiLQp9b4eK9UtkMysaQWDfWGqM73hbCPoK8Xjyi11TNsotPkesrjd5/NYPcgFjggGnO2buPJPGhig==
+  dependencies:
+    base64url "^3.0.1"
+    bn.js "^5.2.0"
+    borsh "^0.5.0"
+    callsites "^4.0.0"
+    fs-extra "^10.0.0"
+    js-sha256 "^0.9.0"
+    near-api-js near/near-api-js#spike/sandbox-runner-tweaks
+    near-sandbox "^0.0.6"
+    near-units "^0.1.9"
+    node-port-check "^2.0.1"
+    promisify-child-process "^4.1.1"
+    pure-uuid "^1.6.2"
+    rimraf "^3.0.2"
+    temp-dir "^2.0.0"
+
 near-sandbox@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/near-sandbox/-/near-sandbox-0.0.6.tgz#d09bdf4bf30cecab1ab4281381903bd6aaabae98"


### PR DESCRIPTION
Jest's default `testMatch` will find ALL files in a `__tests__` directory.

Given the way we set up projects for people, this makes it hard to extract helper files. In https://github.com/near/near-sdk-rs/pull/569, I experienced this first-hand: I wanted to create a `utils.ts` file, and that required me to set up a whole `jest.config.js` and figure out how to extend the one from `near-runner-jest`.

With this change, people can just create utility files right in their `__tests__` directory. The only downside is for Jest power users who might expect to be able to omit the `spec` or `test` from their test filenames.