### PR TITLE
fix: add .near-credentials to bootstrap .gitignore

### DIFF
--- a/packages/jest/bootstrap-starter/near-runner/.gitignore
+++ b/packages/jest/bootstrap-starter/near-runner/.gitignore
@@ -1,3 +1,4 @@
+.near-credentials
 node_modules
 yarn.lock
 package-lock.json


### PR DESCRIPTION
When people run their tests on testnet, near-runner will create a local .near-credentials directory. They should not commit this.