### PR TITLE
build: rename 'publish' to 'release'

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "test:sandbox:ci": "yarn build && jest",
     "test": "yarn test:sandbox && yarn test:testnet",
     "prepare": "husky install",
-    "publish": "yarn lerna publish",
-    "prerelease": "yarn publish --dist-tag next"
+    "release": "yarn lerna publish",
+    "release:prerelease": "yarn publish --dist-tag next"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.12",


### PR DESCRIPTION
`yarn publish` is already a command, so this name doesn't work well with `scripts`

Since the `pre-` prefix means something else in package.json files, this also renames the `prerelease` script to `release:prerelease`.