### PR TITLE
fix: js package needs to come first in workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "private": true,
   "workspaces": [
-    "packages/ava",
-    "packages/js"
+    "packages/js",
+    "packages/ava"
   ]
 }


### PR DESCRIPTION
`js` is a dependency of `ava` so it should come first in the `workspaces` list in `package.json`. If significant changes are made to the `js` package (such as deleting the `lib` directory), it would break things in `ava`.