### PR TITLE
build: fix 'prerelease' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "yarn test:sandbox && yarn test:testnet",
     "prepare": "husky install",
     "release": "yarn lerna publish",
-    "release:prerelease": "yarn publish --dist-tag next"
+    "release:prerelease": "yarn release --dist-tag next"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.12",


### PR DESCRIPTION
`yarn publish` is a yarn command, and besides, we no longer have any script in `scripts` with this name. Need to change it to `yarn release`