### PR TITLE
fix(init): new project's package.json has line breaks

### DIFF
--- a/packages/init/__tests__/no-install.ava.ts
+++ b/packages/init/__tests__/no-install.ava.ts
@@ -1,6 +1,7 @@
 import process from 'process';
 import {join} from 'path';
 import {spawnSync} from 'child_process';
+import * as fs from 'fs/promises';
 import {mkdirSync, pathExists, removeSync} from 'fs-extra';
 import test from 'ava';
 
@@ -16,10 +17,6 @@ test.before(async () => {
   spawnSync('node', [join(__dirname, '../scripts/cli.js'), '--no-install'], {
     cwd: TEST_PROJECT,
   });
-});
-
-test.after.always(() => {
-  removeSync(TEST_PROJECT);
 });
 
 for (const file of [
@@ -45,6 +42,14 @@ test('package.json includes correct version of near-runner-ava', t => {
   const {version} = require(join(__dirname, '../package.json')); // eslint-disable-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
   const packageJson = require(join(TEST_PROJECT, 'near-runner/package.json')); // eslint-disable-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
   t.is(packageJson.devDependencies!['near-runner-ava'], version); // eslint-disable-line @typescript-eslint/no-unsafe-member-access
+});
+
+test('package.json is well-formatted with line breaks', async t => {
+  t.regex(
+    (await fs.readFile(join(TEST_PROJECT, 'near-runner/package.json'))).toString(),
+    /{\n/,
+    'expected first line of file to only contain an opening bracket',
+  );
 });
 
 test('tests pass in new project since it is nested in monorepo and has access to monorepo dependencies', t => {

--- a/packages/init/scripts/cli.js
+++ b/packages/init/scripts/cli.js
@@ -48,7 +48,7 @@ const packageJsonFile = join(process.cwd(), 'near-runner/package.json');
 const version = require(join(__dirname, '../package.json')).version;
 const packageJson = require(packageJsonFile);
 packageJson.devDependencies['near-runner-ava'] = version;
-writeJsonSync(packageJsonFile, packageJson);
+writeJsonSync(packageJsonFile, packageJson, { spaces: 2 });
 
 if (!process.argv.includes('--no-install')) {
   const install = spawnSync('npm', ['install'], {


### PR DESCRIPTION
Add test to ensure that the package.json generated by near-runner-init is well-formatted, and update the script to format it.

Also stops removing the `test-near-runner-init` directory from the project after the test run, to make it easier to visually inspect a newly-created project. This directory is already gitignored.